### PR TITLE
Adding query timeout to the ODBC Genserver.call

### DIFF
--- a/lib/mssqlex/odbc.ex
+++ b/lib/mssqlex/odbc.ex
@@ -46,7 +46,8 @@ defmodule Mssqlex.ODBC do
   def query(pid, statement, params) do
     if Process.alive?(pid) do
       GenServer.call(pid,
-        {:query, %{statement: IO.iodata_to_binary(statement), params: params}})
+        {:query, %{statement: IO.iodata_to_binary(statement), params: params}},
+        Keyword.get(params, :timeout, 5000))
     else
       {:error, %Mssqlex.Error{message: :no_connection}}
     end


### PR DESCRIPTION
Timeouts of > 5000ms weren't effective because the default GenServer timeout is 5s and the Genserver call would timeout before the query had a chance to finish.

This will pass the timeout to the GenServer call so that doesn't happen.