### PR TITLE
Fixing allowing Named Instances, adding it as an option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ services:
 
 install:
   - docker-compose build mssqlex
+  - docker-compose build mssqlex_custom_port
 
 script:
   - docker-compose run mssqlex

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,9 @@ services:
 
 install:
   - docker-compose build mssqlex
-  - docker-compose build mssqlex_custom_port
 
 script:
   - docker-compose run mssqlex
-  - docker-compose run mssqlex_custom_port
 
 after_script:
   - mix local.hex --force

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
 
 script:
   - docker-compose run mssqlex
+  - docker-compose run mssqlex_custom_port
 
 after_script:
   - mix local.hex --force

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,33 +6,34 @@ services:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=TestPa$$word123
 
-  sql_server_custom_port:
-    image: microsoft/mssql-server-linux
-    environment:
-      - ACCEPT_EULA=Y
-      - SA_PASSWORD=R3E11*88
-      - MSSQL_TCP_PORT=4331
-
   mssqlex:
     build: .
     environment:
       - MIX_ENV=test
       - MSSQL_UID=sa
       - MSSQL_PWD=TestPa$$word123
-      - MSSQL_HST=tcp:sql_server,1433
+      - MSSQL_HST=sql_server
       - TRAVIS_JOB_ID=$TRAVIS_JOB_ID
     depends_on:
       - sql_server
     command: ["./wait-for-it.sh", "sql_server:1433", "--", "mix", "coveralls.travis"]
 
-  mssqlex_custom_port:
+  sql_server_custom:
+    image: microsoft/mssql-server-linux
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=R3E11*88
+      - MSSQL_TCP_PORT=9204
+
+  mssqlex_custom:
     build: .
     environment:
       - MIX_ENV=test
       - MSSQL_UID=sa
       - MSSQL_PWD=R3E11*88
-      - MSSQL_HST=tcp:sql_server_custom_port,4331
-      - TRAVIS_JOB_ID=$TRAVIS_JOB_ID
+      - MSSQL_HST=sql_server_custom
+      - MSSQL_IN=MSSQLSERVER
+      - MSSQL_PRT=9204
     depends_on:
-      - sql_server_custom_port
-    command: ["./wait-for-it.sh", "sql_server_custom_port:4331", "--", "mix", "test"]
+      - sql_server_custom
+    command: ["./wait-for-it.sh", "sql_server_custom:9204", "--", "mix", "test"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,13 @@ services:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=TestPa$$word123
 
+  sql_server_custom_port:
+    image: microsoft/mssql-server-linux
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=R3E11*88
+      - MSSQL_TCP_PORT=4331
+
   mssqlex:
     build: .
     environment:
@@ -17,3 +24,15 @@ services:
     depends_on:
       - sql_server
     command: ["./wait-for-it.sh", "sql_server:1433", "--", "mix", "coveralls.travis"]
+
+  mssqlex_custom_port:
+    build: .
+    environment:
+      - MIX_ENV=test
+      - MSSQL_UID=sa
+      - MSSQL_PWD=R3E11*88
+      - MSSQL_HST=tcp:sql_server_custom_port,4331
+      - TRAVIS_JOB_ID=$TRAVIS_JOB_ID
+    depends_on:
+      - sql_server_custom_port
+    command: ["./wait-for-it.sh", "sql_server_custom_port:4331", "--", "mix", "test"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,4 +19,4 @@ services:
       - TRAVIS_JOB_ID=$TRAVIS_JOB_ID
     depends_on:
       - sql_server
-    command: ["./wait-for-it.sh", "sql_server:1433", "--", "mix", "coveralls.travis"]
+    command: ["./wait-for-it.sh", "sql_server:9204", "--", "mix", "coveralls.travis"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=TestPa$$word123
+      - MSSQL_TCP_PORT=9204
 
   mssqlex:
     build: .
@@ -13,27 +14,9 @@ services:
       - MSSQL_UID=sa
       - MSSQL_PWD=TestPa$$word123
       - MSSQL_HST=sql_server
+      - MSSQL_IN=MSSQLSERVER
+      - MSSQL_PRT=9204
       - TRAVIS_JOB_ID=$TRAVIS_JOB_ID
     depends_on:
       - sql_server
     command: ["./wait-for-it.sh", "sql_server:1433", "--", "mix", "coveralls.travis"]
-
-  sql_server_custom:
-    image: microsoft/mssql-server-linux
-    environment:
-      - ACCEPT_EULA=Y
-      - SA_PASSWORD=R3E11*88
-      - MSSQL_TCP_PORT=9204
-
-  mssqlex_custom:
-    build: .
-    environment:
-      - MIX_ENV=test
-      - MSSQL_UID=sa
-      - MSSQL_PWD=R3E11*88
-      - MSSQL_HST=sql_server_custom
-      - MSSQL_IN=MSSQLSERVER
-      - MSSQL_PRT=9204
-    depends_on:
-      - sql_server_custom
-    command: ["./wait-for-it.sh", "sql_server_custom:9204", "--", "mix", "test"]

--- a/lib/mssqlex.ex
+++ b/lib/mssqlex.ex
@@ -18,7 +18,7 @@ defmodule Mssqlex do
     * `:odbc_driver` - The driver the adapter will use
       (default: {ODBC Driver 13 for SQL Server})
     * `:hostname` - The server hostname (default: localhost)
-    * `:port` - The server port number (default: 1433)
+    * `:port` - The server port number
     * `:database` - The name of the database
       (default: MSSQL_DB environment variable)
     * `:username` - Username (default: MSSQL_UID environment variable)

--- a/lib/mssqlex.ex
+++ b/lib/mssqlex.ex
@@ -15,14 +15,22 @@ defmodule Mssqlex do
 
   `opts` expects a keyword list with zero or more of:
 
-    * `:odbc_driver` - The driver the adapter will use
-      (default: {ODBC Driver 13 for SQL Server})
-    * `:hostname` - The server hostname (default: localhost)
-    * `:port` - The server port number
-    * `:database` - The name of the database
-      (default: MSSQL_DB environment variable)
-    * `:username` - Username (default: MSSQL_UID environment variable)
-    * `:password` - User password (default: MSSQL_PWD environment variable)
+    * `:odbc_driver` - The driver the adapter will use.
+        * environment variable: `MSSQL_DVR`
+        * default value: {ODBC Driver 13 for SQL Server}
+    * `:hostname` - The server hostname.
+        * environment variable: `MSSQL_HST`
+        * default value: localhost
+    * `:instance_name` - OPTIONAL. The name of the instance, if using named instances.
+        * environment variable: `MSSQL_IN`
+    * `:port` - OPTIONAL. The server port number.
+        * environment variable: `MSSQL_PRT`
+    * `:database` - The name of the database.
+        * environment variable: `MSSQL_DB`
+    * `:username` - Username.
+        * environment variable: `MSSQL_UID`
+    * `:password` - User's password.
+        * environment variable: `MSSQL_PWD`
 
   `Mssqlex` uses the `DBConnection` framework and supports all `DBConnection`
   options like `:idle`, `:after_connect` etc.

--- a/lib/mssqlex/protocol.ex
+++ b/lib/mssqlex/protocol.ex
@@ -46,7 +46,7 @@ defmodule Mssqlex.Protocol do
     port = opts[:port] || System.get_env("MSSQL_PRT")
 
     conn_opts = [
-      {"Driver", opts[:odbc_driver] || "{ODBC Driver 13 for SQL Server}"},
+      {"Driver", opts[:odbc_driver] || System.get_env("MSSQL_DVR") || "{ODBC Driver 13 for SQL Server}"},
       {"Server", build_server_address(server_address, instance_name, port)},
       {"Database", opts[:database] || System.get_env("MSSQL_DB")},
       {"UID", opts[:username] || System.get_env("MSSQL_UID")},

--- a/lib/mssqlex/protocol.ex
+++ b/lib/mssqlex/protocol.ex
@@ -40,10 +40,15 @@ defmodule Mssqlex.Protocol do
   @spec connect(opts :: Keyword.t) :: {:ok, state}
                                     | {:error, Exception.t}
   def connect(opts) do
+
+    server_address = opts[:hostname] || System.get_env("MSSQL_HST") || "localhost"
+    instance_name = opts[:instance_name] || System.get_env("MSSQL_IN")
+    port = opts[:port] || System.get_env("MSSQL_PRT")
+
     conn_opts = [
-      {"DRIVER", opts[:odbc_driver] || "{ODBC Driver 13 for SQL Server}"},
-      {"SERVER", (opts[:hostname] || System.get_env("MSSQL_HST") || "localhost") <> "," <> (opts[:port] || "1433")},
-      {"DATABASE", opts[:database] || System.get_env("MSSQL_DB")},
+      {"Driver", opts[:odbc_driver] || "{ODBC Driver 13 for SQL Server}"},
+      {"Server", build_server_address(server_address, instance_name, port)},
+      {"Database", opts[:database] || System.get_env("MSSQL_DB")},
       {"UID", opts[:username] || System.get_env("MSSQL_UID")},
       {"PWD", opts[:password] || System.get_env("MSSQL_PWD")}
     ]
@@ -61,6 +66,14 @@ defmodule Mssqlex.Protocol do
       response -> response
     end
   end
+
+  @spec build_server_address(String.t, String.t, String.t) :: String.t
+  defp build_server_address(server_address, instance_name, port)
+
+  defp build_server_address(server_address, nil, nil), do: server_address
+  defp build_server_address(server_address, instance_name, nil), do: "#{server_address}\\#{instance_name}"
+  defp build_server_address(server_address, nil, port), do: "#{server_address},#{port}"
+  defp build_server_address(server_address, instance_name, port), do: "#{server_address}\\#{instance_name},#{port}"
 
   @doc false
   @spec disconnect(err :: Exception.t, state) :: :ok


### PR DESCRIPTION
Fixes the re-opening of https://github.com/findmypast-oss/mssql_ecto/issues/6 once it is pulled into [mssql_ecto](https://github.com/findmypast-oss/mssql_ecto).

Adds `:instance_name` as an option to be given when connecting to a database.

This is tested with Travis by using a named instance, the default named instance `MSSQLSERVER`.

This PR also allows all options to be set through environment variables.