### PR TITLE
Allow configuring the encryption parameters

### DIFF
--- a/lib/mssqlex.ex
+++ b/lib/mssqlex.ex
@@ -31,6 +31,10 @@ defmodule Mssqlex do
         * environment variable: `MSSQL_UID`
     * `:password` - User's password.
         * environment variable: `MSSQL_PWD`
+    * `:encrypt` - Specifies whether data should be encrypted before sending it over the network.
+        * environment variable: `MSSQL_ENCRYPT`
+    * `:trust_server_certificate` - When used with Encrypt, enables encryption using a self-signed server certificate.
+        * environment variable: `MSSQL_TRUST_SERVER_CERT`
 
   `Mssqlex` uses the `DBConnection` framework and supports all `DBConnection`
   options like `:idle`, `:after_connect` etc.

--- a/lib/mssqlex/protocol.ex
+++ b/lib/mssqlex/protocol.ex
@@ -44,13 +44,17 @@ defmodule Mssqlex.Protocol do
     server_address = opts[:hostname] || System.get_env("MSSQL_HST") || "localhost"
     instance_name = opts[:instance_name] || System.get_env("MSSQL_IN")
     port = opts[:port] || System.get_env("MSSQL_PRT")
+    encrypt = opts[:encrypt] || System.get_env("MSSQL_ENCRYPT")
+    trust = opts[:trust_server_certificate] || System.get_env("MSSQL_TRUST_SERVER_CERT")
 
     conn_opts = [
       {"Driver", opts[:odbc_driver] || System.get_env("MSSQL_DVR") || "{ODBC Driver 17 for SQL Server}"},
       {"Server", build_server_address(server_address, instance_name, port)},
       {"Database", opts[:database] || System.get_env("MSSQL_DB")},
       {"UID", opts[:username] || System.get_env("MSSQL_UID")},
-      {"PWD", opts[:password] || System.get_env("MSSQL_PWD")}
+      {"PWD", opts[:password] || System.get_env("MSSQL_PWD")},
+      {"Encrypt", to_yesno(encrypt)},
+      {"TrustServerCertificate", to_yesno(trust)}
     ]
     conn_str = Enum.reduce(conn_opts, "", fn {key, value}, acc ->
       acc <> "#{key}=#{value};" end)
@@ -74,6 +78,9 @@ defmodule Mssqlex.Protocol do
   defp build_server_address(server_address, instance_name, nil), do: "#{server_address}\\#{instance_name}"
   defp build_server_address(server_address, nil, port), do: "#{server_address},#{port}"
   defp build_server_address(server_address, instance_name, port), do: "#{server_address}\\#{instance_name},#{port}"
+
+  defp to_yesno(value) when value in ["yes", true], do: "yes"
+  defp to_yesno(value) when value in ["no", nil, false], do: "no"
 
   @doc false
   @spec disconnect(err :: Exception.t, state) :: :ok

--- a/test/mssqlex/login_test.exs
+++ b/test/mssqlex/login_test.exs
@@ -3,10 +3,22 @@ defmodule Mssqlex.LoginTest do
 
   alias Mssqlex.Result
 
+  @check_encryption """
+  SELECT encrypt_option
+  FROM sys.dm_exec_connections
+  WHERE session_id = @@SPID
+  """
+
   test "Given valid details, connects to database" do
     assert {:ok, pid} = Mssqlex.start_link([])
     assert {:ok, _, %Result{num_rows: 1, rows: [["test"]]}} =
       Mssqlex.query(pid, "SELECT 'test'", [])
+  end
+
+  test "connects with encryption" do
+    assert {:ok, pid} = Mssqlex.start_link(encrypt: true, trust_server_certificate: true)
+    assert {:ok, _, %Result{num_rows: 1, rows: [["TRUE"]]}} =
+      Mssqlex.query(pid, @check_encryption, [])
   end
 
   test "Given invalid details, errors" do


### PR DESCRIPTION
This allows configuring the connection's encryption.

## Description

This just adds two extra flags to the connection string.

## Motivation and Context
Some people like encryption.

## How Has This Been Tested?
I ran the tests. I also wrote a new test that checks that the current connection has encryption.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
