### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 
 language: elixir
 elixir:
-  - 1.5
+  - 1.6.5
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - docker-compose build mssqlex
 
 script:
-  - docker-compose run mssqlex
+  - docker-compose run mssqlex mix coveralls.travis
 
 after_script:
   - mix local.hex --force

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - docker-compose build mssqlex
 
 script:
+  - docker-compose run mssqlex mix compile --warnings-as-errors
   - docker-compose run mssqlex mix coveralls.travis
 
 after_script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.5
+FROM elixir:1.6.5-slim
 
 # --- Set Locale to en_US.UTF-8 ---
 
@@ -14,13 +14,12 @@ ENV LC_ALL en_US.UTF-8
 
 # --- MSSQL ODBC INSTALL ---
 
-RUN apt-get update && apt-get install -y --no-install-recommends apt-transport-https
-
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-&& curl https://packages.microsoft.com/config/debian/8/prod.list | tee -a /etc/apt/sources.list.d/mssql-release.list \
-&& apt-get update \
-&& ACCEPT_EULA=Y apt-get install msodbcsql -y \
-&& apt-get install unixodbc-dev -y
+RUN apt-get update && \
+    apt-get -y install curl apt-transport-https gnupg2 && \
+    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+    curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get update && \
+    ACCEPT_EULA=Y apt-get install -y msodbcsql17
 
 # --- APP INSTALL ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN mix local.hex --force && \
 
 COPY . /usr/src/app
 WORKDIR /usr/src/app
-RUN mix do deps.get
+RUN mix do deps.get, deps.compile
 
 # --- Be able to run wait for it script ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,4 +20,7 @@ services:
       - TRAVIS_JOB_ID=$TRAVIS_JOB_ID
     depends_on:
       - sql_server
-    command: ["./wait-for-it.sh", "sql_server:9204", "-s", "--", "mix", "coveralls.travis"]
+    volumes:
+      - .:/usr/src/app/
+    entrypoint: ./wait-for-it.sh sql_server:9204 --
+    command: mix test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - MSSQL_HST=sql_server
       - MSSQL_IN=MSSQLSERVER
       - MSSQL_PRT=9204
-      - MSSQL_DVR={ODBC Driver 13 for SQL Server}
+      - MSSQL_DVR={ODBC Driver 17 for SQL Server}
       - TRAVIS_JOB_ID=$TRAVIS_JOB_ID
     depends_on:
       - sql_server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,5 +22,7 @@ services:
       - sql_server
     volumes:
       - .:/usr/src/app/
+      - /usr/src/app/deps
+      - /usr/src/app/_build
     entrypoint: ./wait-for-it.sh sql_server:9204 --
     command: mix test


### PR DESCRIPTION
This builds on your work in #19.

* This upgrades your Elixir version on CI to the latest.
* Uses the `slim` variant image, which should be a little smaller of a download.
* Uses msodbcsql17 in the docker image.
* Prevents compiler warnings on CI.
* Create a volume in the docker-compose file so that files get synced into the container for development. This way, if you change a file, you can just rerun `docker-compose run mssqlex`.
* Moved `wait-for-it.sh` to the entrypoint in the docker-compose, so we always wait for mssql.
* Set the default `docker-compose` command to `mix test`, because `coveralls.travis` only works on CI.

I would also recommend using running `mix format` against this project and add this step to your travis config: `docker-compose run mssqlex mix format --check-formatted`